### PR TITLE
Remove lock file for db_spesification.xlsx#

### DIFF
--- a/.~lock.db_spesification.xlsx#
+++ b/.~lock.db_spesification.xlsx#
@@ -1,1 +1,0 @@
-,pr001,linux,29.01.2024 08:28,file:///home/pr001/.config/libreoffice/4;


### PR DESCRIPTION
This lock file was inadvertently committed and is unnecessary for version control.
Removing it to avoid confusion and ensure a clean repository state.

Signed-off-by: Memet Zx <zxce3@gnuweeb.org>
